### PR TITLE
Fix Vehicle Resell Circle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -45,6 +45,7 @@ function PlayerManagement()
 		else
 			Config.Zones.ShopEntering.Type = -1
 			Config.Zones.BossActions.Type  = -1
+			Config.Zones.ResellVehicle.Type = -1
 		end
 	end
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -335,7 +335,7 @@ end)
 ESX.RegisterServerCallback('esx_vehicleshop:resellVehicle', function(source, cb, plate, model)
 	local xPlayer, resellPrice = ESX.GetPlayerFromId(source)
 
-	if xPlayer.job.name == 'cardealer' then
+	if xPlayer.job.name == 'cardealer' or not Config.EnablePlayerManagement then
 		-- calculate the resell price
 		for i=1, #vehicles, 1 do
 			if GetHashKey(vehicles[i].model) == model then


### PR DESCRIPTION
If Enable Player Management is off, allow anyone to resell their vehicle (did not work before)
If Enable Player Management is on, only show the resell circle to employees.