### PR TITLE
added workaround for empty categories

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -140,7 +140,8 @@ function OpenShopMenu()
 		local category         = Categories[i]
 		local categoryVehicles = vehiclesByCategory[category.name]
 		local options          = {}
-
+		if categoryVehicles == nil then goto continue end
+		
 		for j=1, #categoryVehicles, 1 do
 			local vehicle = categoryVehicles[j]
 
@@ -161,6 +162,7 @@ function OpenShopMenu()
 			max     = #Categories[i],
 			options = options
 		})
+		::continue::
 	end
 
 	ESX.UI.Menu.Open('default', GetCurrentResourceName(), 'vehicle_shop', {


### PR DESCRIPTION
^1SCRIPT ERROR: @esx_vehicleshop/client/main.lua:154: attempt to get length of a nil value (local 'categoryVehicles')^7 Will break the script